### PR TITLE
Use baseurl instead of siteurl, change absolute links to relative

### DIFF
--- a/_includes/css.html
+++ b/_includes/css.html
@@ -1,7 +1,7 @@
         <link rel="stylesheet" type="text/css" media="all" href="//fonts.googleapis.com/css?family=Open+Sans:400,700,400italic,700italic">
         <link rel="stylesheet" type="text/css" media="all" href="//fonts.googleapis.com/css?family=Nunito">
-        <link rel="stylesheet" type="text/css" media="all" href="{{ site.url }}/css/font-awesome.min.css">
-        <link rel="stylesheet" type="text/css" media="all" href="{{ site.url }}/css/foundation.min.css">
-        <link rel="stylesheet" type="text/css" media="all" href="{{ site.url }}/css/responsive-tables.css">
-        <link rel="stylesheet" type="text/css" media="all" href="{{ site.url }}/css/openmicroscopy.css">
-        <link rel="stylesheet" type="text/css" media="all" href="{{ site.url }}/css/idr.css">
+        <link rel="stylesheet" type="text/css" media="all" href="{{ site.baseurl }}/css/font-awesome.min.css">
+        <link rel="stylesheet" type="text/css" media="all" href="{{ site.baseurl }}/css/foundation.min.css">
+        <link rel="stylesheet" type="text/css" media="all" href="{{ site.baseurl }}/css/responsive-tables.css">
+        <link rel="stylesheet" type="text/css" media="all" href="{{ site.baseurl }}/css/openmicroscopy.css">
+        <link rel="stylesheet" type="text/css" media="all" href="{{ site.baseurl }}/css/idr.css">

--- a/_includes/footer-idr.html
+++ b/_includes/footer-idr.html
@@ -1,10 +1,10 @@
         <div class="callout large secondary">
             <div class="row">
                 <div class="row small-up-2 medium-up-4 large-up-4">
-                    <div class="column"><img class="thumbnail their-logo" src="http://idr-demo.openmicroscopy.org/about/ome-logo-200.png" alt="OME"></div>
-                    <div class="column"><img class="thumbnail their-logo" src="http://idr-demo.openmicroscopy.org/about/eurobioimaging_logo.gif" alt="Euro-Bioimaging"></div>
-                    <div class="column"><img class="thumbnail their-logo" src="http://idr-demo.openmicroscopy.org/about/bbsrc.png" alt="BBSRC"></div>
-                    <div class="column"><img class="thumbnail their-logo" src="http://idr-demo.openmicroscopy.org/about/h2020.png" alt="Horizon"></div>
+                    <div class="column"><img class="thumbnail their-logo" src="/about/ome-logo-200.png" alt="OME"></div>
+                    <div class="column"><img class="thumbnail their-logo" src="/about/eurobioimaging_logo.gif" alt="Euro-Bioimaging"></div>
+                    <div class="column"><img class="thumbnail their-logo" src="/about/bbsrc.png" alt="BBSRC"></div>
+                    <div class="column"><img class="thumbnail their-logo" src="/about/h2020.png" alt="Horizon"></div>
                 </div>
                 <hr class="whitespace">
                 <div class="large-12 columns text-center">

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,9 +1,9 @@
     <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-    <script src="{{ site.url }}/js/vendor/jquery.js"></script>
-    <script src="{{ site.url }}/js/vendor/what-input.js"></script>
-    <script src="{{ site.url }}/js/vendor/foundation.js"></script>
-    <script src="{{ site.url }}/js/app.js"></script>
-    <script src="{{ site.url }}/js/responsive-tables.js"></script>
+    <script src="{{ site.baseurl }}/js/vendor/jquery.js"></script>
+    <script src="{{ site.baseurl }}/js/vendor/what-input.js"></script>
+    <script src="{{ site.baseurl }}/js/vendor/foundation.js"></script>
+    <script src="{{ site.baseurl }}/js/app.js"></script>
+    <script src="{{ site.baseurl }}/js/responsive-tables.js"></script>
     <script>
         $(document).foundation();
     </script>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ title: Demo
                     <h1 class="hero-main-header">Image Data Resource (IDR)</h1>
                     <p class="hero-subheader small-10 medium-10 large-10 small-offset-1 medium-offset-1 large-offset-1">Welcome to the Image Data Resource (IDR). This online, public data repository seeks to store, integrate and serve image datasets from published scientific studies. We have collected and are continuing to receive existing and newly created “reference image" datasets that are valuable resources for a broad community of users, either because they will be frequently accessed and cited or because they can serve as a basis for re-analysis and the development of new computational tools.</p>
                     <br>
-                    <a href="http://idr-demo.openmicroscopy.org/webclient/userdata/?experimenter=-1" class="large button sites-button">Take a look at the data</a>
+                    <a href="/webclient/userdata/?experimenter=-1" class="large button sites-button">Take a look at the data</a>
                 </div>
             </div>
         </header>
@@ -62,46 +62,46 @@ title: Demo
             <div class="small-10 small-centered medium-10 medium-centered columns">
                 <div class="row horizontal">
                     <div>
-                        <p><a href="http://idr-demo.openmicroscopy.org/webclient/?show=well-45407">Datasets in human cells</a>, <a href="http://idr-demo.openmicroscopy.org/webclient/?show=well-547609">Drosophila</a>, and <a href="http://idr-demo.openmicroscopy.org/webclient/?show=well-590686">fungi</a> are included. The full <a href="http://idr-demo.openmicroscopy.org/webclient/?show=well-771034">Mitocheck dataset</a> and a comprehensive <a href="http://idr-demo.openmicroscopy.org/webclient/?show=plate-4101">chemical screen in human cells</a> are included. Imaging data from <a href="http://idr-demo.openmicroscopy.org/webclient/?show=plate-4751">Tara Oceans</a>, a global survey of plankton and other marine organisms is also included.</p>
+                        <p><a href="/webclient/?show=well-45407">Datasets in human cells</a>, <a href="/webclient/?show=well-547609">Drosophila</a>, and <a href="/webclient/?show=well-590686">fungi</a> are included. The full <a href="/webclient/?show=well-771034">Mitocheck dataset</a> and a comprehensive <a href="/webclient/?show=plate-4101">chemical screen in human cells</a> are included. Imaging data from <a href="/webclient/?show=plate-4751">Tara Oceans</a>, a global survey of plankton and other marine organisms is also included.</p>
                         <p>Wherever possible, functional annotations (e.g., “increased peripheral actin") and experimental components have been converted to defined terms in the <a href="http://www.ebi.ac.uk/ols/ontologies/efo">EFO</a>, <a href="http://www.ebi.ac.uk/ols/ontologies/cmpo">CMPO</a> or other ontologies, always in collaboration with the data submitters (see example). >80% of the functional annotations have links to defined, published controlled vocabularies.</p>
                     </div>
                     <div class="row small-up-2 medium-up-4 large-up-4">
-                        <div class="column"><a href="http://idr-demo.openmicroscopy.org/webclient/?show=image-122770" target="_blank"><img class="thumbnail" src="http://idr-demo.openmicroscopy.org/webgateway/render_thumbnail/122770/192/" alt="OMERO web"></a></div>
-                        <div class="column"><a href="http://idr-demo.openmicroscopy.org/webclient/?show=image-928607" target="_blank"><img class="thumbnail" src="http://idr-demo.openmicroscopy.org/webgateway/render_thumbnail/928607/192/" alt="OMERO web"></a></div>
-                        <div class="column"><a href="http://idr-demo.openmicroscopy.org/webclient/?show=image-1230008" target="_blank"><img class="thumbnail" src="http://idr-demo.openmicroscopy.org/webgateway/render_thumbnail/1230008/192/" alt="OMERO web"></a></div>
-                        <div class="column"><a href="http://idr-demo.openmicroscopy.org/webclient/?show=image-1484759" target="_blank"><img class="thumbnail" src="http://idr-demo.openmicroscopy.org/webgateway/render_thumbnail/1484759/192/" alt="OMERO web"></a></div>
+                        <div class="column"><a href="/webclient/?show=image-122770" target="_blank"><img class="thumbnail" src="/webgateway/render_thumbnail/122770/192/" alt="OMERO web"></a></div>
+                        <div class="column"><a href="/webclient/?show=image-928607" target="_blank"><img class="thumbnail" src="/webgateway/render_thumbnail/928607/192/" alt="OMERO web"></a></div>
+                        <div class="column"><a href="/webclient/?show=image-1230008" target="_blank"><img class="thumbnail" src="/webgateway/render_thumbnail/1230008/192/" alt="OMERO web"></a></div>
+                        <div class="column"><a href="/webclient/?show=image-1484759" target="_blank"><img class="thumbnail" src="/webgateway/render_thumbnail/1484759/192/" alt="OMERO web"></a></div>
                     <div class="row small-up-2 medium-up-4 large-up-4">
                         <!--
-                        <div class="column"><a href="http://idr-demo.openmicroscopy.org/webclient/img_detail/179754/?c=1|167:2000$FF0000,2|288:4095$00FF00&m=c&p=normal&ia=0&q=0.9&t=294&z=1&zm=47&x=0&y=0" target="_blank">
+                        <div class="column"><a href="/webclient/img_detail/179754/?c=1|167:2000$FF0000,2|288:4095$00FF00&m=c&p=normal&ia=0&q=0.9&t=294&z=1&zm=47&x=0&y=0" target="_blank">
                                 <img class="thumbnail" alt="idr0002-A"
-                                    src="http://idr-demo.openmicroscopy.org/webclient/img_detail/179754/?c=1|167:2000$FF0000,2|288:4095$00FF00&m=c&p=normal&ia=0&q=0.9&t=294&z=1&zm=47&x=0&y=0"></a></div>
+                                    src="/webclient/img_detail/179754/?c=1|167:2000$FF0000,2|288:4095$00FF00&m=c&p=normal&ia=0&q=0.9&t=294&z=1&zm=47&x=0&y=0"></a></div>
                         -->
-                        <div class="column"><a href="http://idr-demo.openmicroscopy.org/webclient/?show=well-4890" target="_blank">
+                        <div class="column"><a href="/webclient/?show=well-4890" target="_blank">
                                 <img class="thumbnail" alt="idr0003-A"
-                                    src="http://idr-demo.openmicroscopy.org/webgateway/render_thumbnail/14269/192/"></a></div>
-                        <div class="column"><a href="http://idr-demo.openmicroscopy.org/webclient/?show=well-37013" target="_blank">
+                                    src="/webgateway/render_thumbnail/14269/192/"></a></div>
+                        <div class="column"><a href="/webclient/?show=well-37013" target="_blank">
                                 <img class="thumbnail" alt="idr0007-A"
-                                    src="http://idr-demo.openmicroscopy.org/webgateway/render_thumbnail/95543/192/"></a></div>
-                        <div class="column"><a href="http://idr-demo.openmicroscopy.org/webclient/?show=well-1259927" target="_blank">
+                                    src="/webgateway/render_thumbnail/95543/192/"></a></div>
+                        <div class="column"><a href="/webclient/?show=well-1259927" target="_blank">
                                 <img class="thumbnail" alt="idr0010-A"
-                                    src="http://idr-demo.openmicroscopy.org/webgateway/render_thumbnail/3054590/192/"></a></div>
-                        <div class="column"><a href="http://idr-demo.openmicroscopy.org/webclient/?show=image-2858285" target="_blank">
+                                    src="/webgateway/render_thumbnail/3054590/192/"></a></div>
+                        <div class="column"><a href="/webclient/?show=image-2858285" target="_blank">
                                 <img class="thumbnail" alt="idr0027"
-                                    src="http://idr-demo.openmicroscopy.org/webgateway/render_thumbnail/2858285/192/"></a></div>
+                                    src="/webgateway/render_thumbnail/2858285/192/"></a></div>
                     </div>
                     <div class="row small-up-2 medium-up-4 large-up-4">
-                        <div class="column"><a href="http://idr-demo.openmicroscopy.org/webclient/?show=image-1920093" target="_blank">
+                        <div class="column"><a href="/webclient/?show=image-1920093" target="_blank">
                                 <img class="thumbnail" alt="idr0018"
-                                    src="http://idr-demo.openmicroscopy.org/webgateway/render_thumbnail/1920093/192/"></a></div>
-                        <div class="column"><a href="http://idr-demo.openmicroscopy.org/webclient/?show=image-1919049" target="_blank">
+                                    src="/webgateway/render_thumbnail/1920093/192/"></a></div>
+                        <div class="column"><a href="/webclient/?show=image-1919049" target="_blank">
                                 <img class="thumbnail" alt="idr0018"
-                                    src="http://idr-demo.openmicroscopy.org/webgateway/render_thumbnail/1919049/192/"></a></div>
-                        <div class="column"><a href="http://idr-demo.openmicroscopy.org/webclient/?show=well-1024987" target="_blank">
+                                    src="/webgateway/render_thumbnail/1919049/192/"></a></div>
+                        <div class="column"><a href="/webclient/?show=well-1024987" target="_blank">
                                 <img class="thumbnail" alt="idr0019"
-                                    src="http://idr-demo.openmicroscopy.org/webgateway/render_thumbnail/1859680/192/"></a></div>
-                        <div class="column"><a href="http://idr-demo.openmicroscopy.org/webclient/?show=image-1885618" target="_blank">
+                                    src="/webgateway/render_thumbnail/1859680/192/"></a></div>
+                        <div class="column"><a href="/webclient/?show=image-1885618" target="_blank">
                                 <img class="thumbnail" alt="idr0023"
-                                    src="http://idr-demo.openmicroscopy.org/webgateway/render_thumbnail/1885618/192/"></a></div>
+                                    src="/webgateway/render_thumbnail/1885618/192/"></a></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
There was previously a mix of `site.url` and `site.baseurl`, this standardises on `site.baseurl` so it can be set as an argument in `jekyll build ... --baseurl /about`.

This also replaces all the absolute URLs beginning `http://idr-demo.openmicroscopy.org/` with a relative url (`/`), and as a consequence it appears there are some missing images that were being pulled direct from http://idr-demo.openmicroscopy.org/