### PR TITLE
Update deployment docs to reference docs in IDR deployment github

### DIFF
--- a/deployment.html
+++ b/deployment.html
@@ -8,12 +8,12 @@ title: Deployment
             <div class="row homepage text-center">
 
                 <div class="medium-12 columns">
-                    <h1 class="hero-main-header">Openstack and IDR Playbooks</h1>
+                    <h1 class="hero-main-header">Openstack and IDR Ansible Playbooks</h1>
                     <p class="hero-subheader small-10 medium-10 large-10 small-offset-1 medium-offset-1 large-offset-1">
-                    The Image Data Resource (IDR) infrastructure is managed using <a href="https://www.ansible.com/">Ansible</a>. This includes provisioning virtual resources on OpenStack.
+                    The Image Data Resource (IDR) infrastructure is managed using <a href="https://www.ansible.com/">Ansible</a>. This includes provisioning virtual resources on an <a href="https://www.openstack.org/">OpenStack</a> cloud at <a href="https://www.ebi.ac.uk/">EMBL-EBI</a>.
                     </p>
                     <p class="hero-subheader small-10 medium-10 large-10 small-offset-1 medium-offset-1 large-offset-1">
-                    Any queries should be sent to ome-devel@lists.openmicroscopy.org.uk
+                    Any queries should be sent to the <a href="http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/">ome-devel@lists.openmicroscopy.org.uk mailing list</a>
                     </p>
                 </div>
             </div>
@@ -22,23 +22,20 @@ title: Deployment
         <!-- begin Background section -->
         <hr class="whitespace">
         <div class="row column text-center">
-            <h2>Background</h2>
+            <h2>Servers</h2>
         </div>
         <hr>
         <div class="row">
             <div class="small-10 small-centered medium-10 medium-centered columns">
                 <div class="row horizontal">
                     <div>
-                        <p>The main production IDR (https://idr-demo.openmicroscopy.org/) consists of three servers:</p>
+                        <p>The main <a href="https://idr-demo.openmicroscopy.org/webclient/userdata/?experimenter=-1">production IDR</a> consists of three servers:</p>
                         <ul>
-                            <li>Database: A dedicated PostgreSQL server.</li>
-                            <li>OMERO: OMERO.server and OMERO.web with a highly customised configuration optimised for the data access patterns of the IDR.</li>
-                            <li>Web proxy: Front-end Nginx proxy that mediates all public access to the IDR. It incorporates an aggressive caching configuration to reduce the load on OMERO.</li>
+                            <li>Database: A dedicated <a href="https://www.postgresql.org/">PostgreSQL</a> server.</li>
+                            <li>OMERO: <a href="https://www.openmicroscopy.org/">OMERO.server and OMERO.web</a> with a highly customised configuration optimised for the data access patterns of the IDR.</li>
+                            <li>Web proxy: Front-end <a href="https://nginx.org/">Nginx</a> proxy that mediates all public access to the IDR. It incorporates an aggressive caching configuration to reduce the load on OMERO.</li>
                         </ul>
-                        <p>Details of the configuration for these servers are in `idr-playbooks/group_vars/`.</p>
-                        <p>The playbooks are designed to handle the setup of all servers together, including configuring internal network addresses so that OMERO can talk to the database, and the web proxy can talk to OMERO.</p>
-                        <br>
-                        <p>In addition to the production IDR we also have playbooks for setting up the analysis platform based around
+                        <p>In addition to the production IDR we also have a virtual analysis platform based around
                         <a href="https://github.com/jupyterhub/jupyterhub">JupyterHub</a> and
                         <a href="https://docs.docker.com/engine/swarm/">Docker Swarm</a>.
                         This uses a separate copy of the IDR to ensure that heavy access loads resulting from analysis workflows do not have a detrimental impact on the production server, and requires three or more servers:</p>
@@ -48,183 +45,10 @@ title: Deployment
                             <li>Docker manager: The central controlling node for a Docker Swarm running JupyterHub.</li>
                             <li>Docker workers: In addition to the Docker manager zero or more Docker workers can be included in the analysis platform. If multiple users are logged on to JupyterHub they should be automatically spread amongst all Docker servers.</li>
                         </ul>
+                        <p>The <a href="https://github.com/IDR/deployment/">IDR deployment GitHub repository</a> contains Ansible playbooks and full instructions for <a href="https://github.com/IDR/deployment/blob/master/docs/provisioning.md">provisioning resources</a> and <a href="https://github.com/IDR/deployment/blob/master/docs/deployment.md">deploying the IDR</a>, as well as our <a href="https://github.com/IDR/deployment/blob/master/docs/operating-procedures.md">internal operating procedures</a>.</p>
 
-<!--
-TODO: Access to this platform is handled by the same web proxy used for the production IDR.
-
-TODO: A diagram?
--->
-
-                        <p> These instructions assume a working knowledge of Ansible, and will setup a combined production IDR and Analysis platform.
-                        This should provided sufficient information for you to customise your installation to your own requirements.</p>
-                        <p> The playbooks are mostly tested with OpenStack since that is our deployment platform, and this is the easiest way to setup the IDR.
-                        They should also work with other clouds or physical infrastructure, but you will have to setup the Ansible inventory yourself.</p>
                     </div>
                 </div>
             </div>
         </div>
         <!-- end Background section -->
-
-        <!-- begin Setup section -->
-        <hr class="whitespace">
-        <div class="row column text-center">
-            <h2>Initial setup</h2>
-        </div>
-        <hr>
-        <div class="row">
-            <div class="small-10 small-centered medium-10 medium-centered columns">
-                <div class="row horizontal">
-                    <div>
-                        <p>The Ansible playbooks are stored on
-                        <a href="https://github.com/IDR/deployment/">GitHub</a>.
-                        Clone this directory, and change into the `ansible` directory:</p>
-                        <pre>
-    git clone --recursive https://github.com/IDR/deployment.git
-    cd deployment/ansible
-                        </pre>
-
-<!--
-TODO: Link to a tag
--->
-
-                        <p>The following sections in this document describe how to create the virtual machines and storage volumes for the IDR on OpenStack, and to install the IDR.
-If you already have access to your own resources, whether physical or virtual, you can skip down to "Installing the IDR (own infrastructure)".</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <!-- end Setup section -->
-
-        <!-- begin Creation section -->
-        <hr class="whitespace">
-        <div class="row column text-center">
-            <h2>Creation of virtual machines and storage volumes on OpenStack</h2>
-        </div>
-        <hr>
-        <div class="row">
-            <div class="small-10 small-centered medium-10 medium-centered columns">
-                <div class="row horizontal">
-                    <div>
-                        <p>The playbooks used to provision the virtual hardware for the IDR contain private configuration information which is specific to our OpenStack tenancy.
-                        A generic playbook is provided: `openstack-create-infrastructure.yml`.
-                        Edit the variables in your inventory or the playbook to correspond to your OpenStack project, and
-                        <a href="http://docs.openstack.org/user-guide/common/cli_set_environment_variables_using_openstack_rc.html">setup your OpenStack environment variables</a>.</p>
-                        <p>
-                        Create the IDR resources by running:
-                        </p>
-                        <pre>
-    ansible-playbook openstack-create-infrastructure.yml
-                        </pre>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <!-- end Creation section -->
-
-        <!-- begin Deployment section -->
-        <hr class="whitespace">
-        <div class="row column text-center">
-            <h2>Installing the IDR on Openstack</h2>
-        </div>
-        <hr>
-        <div class="row">
-            <div class="small-10 small-centered medium-10 medium-centered columns">
-                <div class="row horizontal">
-                    <div>
-                        <p>The IDR OpenStack playbooks assume only one floating IP is available.
-                        This means it is necessary to connect to servers via a bastion host.
-                        This can be done by setting an SSH `ProxyCommand` in your SSH `config` file, or on the  Ansible command line.</p>
-
-                        <p>A helper playbook `os-idr-playbooks/os-idr-ansible-command-helper.yml` is included to assist with setting the required Ansible SSH options:</p>
-
-                        <pre>
-    ansible-playbook -i inventory/openstack-private.py \
-        os-idr-playbooks/os-idr-ansible-command-helper.yml \
-        -e idr_environment=idr
-                        </pre>
-
-                        <p>`inventory/openstack-private.py` is an OpenStack dynamic inventory script that will return the private IPs of each instance. `idr_environment` is a variable intended to allow hosting of multiple IDR versions on the same tenancy, the default `idr` should work if you have only one IDR.</p>
-
-                        <p> This playbook will write the Ansible command line to `/tmp/run-ansible-command.tmp`.
-                            Edit this command if necessary, and run it, for example:</p>
-
-                        <pre>
-    ansible-playbook -i \
-        idr-inventory/openstack-private.py \
-        --diff \
-        -u centos \
-        -e idr_environment=idr \
-        -e ansible_ssh_common_args="'-o ProxyCommand=\\\"ssh \
-            -o UserKnownHostsFile=/dev/null \
-            -o StrictHostKeyChecking=no \
-            -W %h:%p -q centos@10.0.0.3\\\" \
-            -o UserKnownHostsFile=/dev/null \
-            -o StrictHostKeyChecking=no'" \
-        idr-playbooks/idr-00-preinstall.yml \
-        idr-playbooks/idr-01-install-idr.yml \
-        idr-playbooks/idr-02-install-analysis.yml \
-        idr-playbooks/idr-03-postinstall.yml
-                        </pre>
-
-<!--
-
-TODO: The playbooks for the analysis platform are still being finalised/tested.
-
--->
-
-                    </div>
-                </div>
-            </div>
-        </div>
-        <!-- end Deployment section -->
-
-        <!-- begin Installation section -->
-        <hr class="whitespace">
-        <div class="row column text-center">
-            <h2>Installing the IDR (own infrastructure)</h2>
-        </div>
-        <hr>
-        <div class="row">
-            <div class="small-10 small-centered medium-10 medium-centered columns">
-                <div class="row horizontal">
-                    <div>
-                        <p>Create an Ansible inventory with the following groups:</p>
-                        <pre>
-
-    # PostgreSQL server
-    [idr-database-hosts]
-    10.0.0.1
-    # OMERO server
-    [idr-omero-hosts]
-    10.0.0.2
-    # Optional: Front-end web caching proxy
-    [idr-proxy-hosts]
-    10.0.0.3
-    # Optional: analysis platform controller
-    [idr-dockermanager-hosts]
-    10.0.0.4
-    # Optional: Analysis platform slave (multiple allowed)
-    [idr-dockerworker-hosts]
-    10.0.0.5
-                        </pre>
-
-                        <p>Install the IDR:</p>
-
-                        <pre>
-
-    ansible-playbook \
-        -i inventory \
-        idr-playbooks/idr-01-install-idr.yml \
-        idr-playbooks/idr-02-install-analysis.yml
-
-                        </pre>
-
-                        <p> Also run `idr-playbooks/idr-03-postinstall.yml` if you wish to setup or reset the IDR OMERO user accounts.</p>
-
-                        <p>This will generate a self-signed SSL certificate for the Nginx gateway.</p>
-
-                    </div>
-                </div>
-            </div>
-        </div>
-        <!-- end Installation section -->


### PR DESCRIPTION
Removes most of the technical detail from the deployment page and links to https://github.com/IDR/deployment/ which will contain the docs. This should be easier to keep up to date.

--depends-on https://github.com/IDR/deployment/pull/8

To test: `docker run -it --rm -p 4000:4000  -v $PWD:/src jekyll/jekyll jekyll server -w -s /src` and go to `http://localhost:4000/`